### PR TITLE
Enable export for custom events.

### DIFF
--- a/ftw/calendarexport/results.py
+++ b/ftw/calendarexport/results.py
@@ -1,6 +1,7 @@
 from DateTime import DateTime
-from Products.Five import BrowserView
+from Products.ATContentTypes.interface.interfaces import ICalendarSupport
 from Products.CMFCore.utils import getToolByName
+from Products.Five import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.component import getMultiAdapter
 
@@ -38,8 +39,7 @@ class CalendarExportResults(BrowserView):
             end.reverse()
             end = DateTime(*[int(p) for p in end]).latestTime()
             return catalog(dict(
-                portal_type='Event',
+                object_provides = ICalendarSupport.__identifier__,
                 start = {'range':'min', 'query': start},
                 end = {'range':'max', 'query': end}))
         return
-


### PR DESCRIPTION
I want to use this product together with [ftw.contentpage](https://github.com/4teamwork/ftw.contentpage).  The problem is that `ftw.contentpage` replaces the default `Event` type with a custom `EventPage` type.
Due to the different `portal_type` the export doesn't pick up the event and thus it can't be exported.

This PR changes the export query to search for objects who provide `ICalendarSupport`. This was already done the same way [here](https://github.com/4teamwork/ftw.calendarexport/blob/master/ftw/calendarexport/export.py#L27).