### PR TITLE
Fix tests (workaround).

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ maintainer = 'Julian Infanger'
 tests_require = ['plone.app.testing',
                  'ftw.builder',
                  'ftw.testbrowser',
-                 'ftw.testing',
+                 'ftw.testing <= 1.15.0',
                  'unittest2',
                  'plone.app.event',
                  'ftw.events [tests]',


### PR DESCRIPTION
This package installs "ftw.events" from source and "ftw.events" uses an older release of "ftw.testing" because of an incompatibility of "ftw.events" with the latest release of "ftw.testing" (see https://github.com/4teamwork/ftw.events/pull/30/commits/d80ded4710923075b0f1c742137e03f7da227fb1 and https://github.com/4teamwork/ftw.events/issues/32).